### PR TITLE
Add NullSec Linux to Exploitation Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Thank you for reading.
 | --- | --- |
 | Evil-WinRM | https://github.com/Hackplayers/evil-winrm |
 | Metasploit | https://github.com/rapid7/metasploit-framework |
+| NullSec Linux | https://github.com/bad-antics/nullsec-linux |
 
 ### Post Exploitation
 


### PR DESCRIPTION
Adding NullSec Linux - a security-focused distribution with 135+ pentesting tools, perfect for OSCP preparation.

**Features:**
- Pre-installed pentest tools matching OSCP syllabus
- Specialized editions for different assessment types
- Regular tool updates

GitHub: https://github.com/bad-antics/nullsec-linux